### PR TITLE
fix: use react 17 or 18 as peer dependency

### DIFF
--- a/packages/package.json
+++ b/packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junyiacademy/perseus-core",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",
@@ -15,7 +15,7 @@
     "build:publish": "webpack --config webpack.config.js --progress"
   },
   "peerDependencies": {
-    "react": "17.0.2",
-    "react-dom": "17.0.2"
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   }
 }


### PR DESCRIPTION
> Pull Request Title 請加上 prefix，e.g. New:/Fix:/Change:/Refactor:/Chore:/Test:/Doc: ...

**Notion Link:** 

https://www.notion.so/junyiacademy/typescript-4e00ee5d1ba14c4a894babab4a7d3ed8

#### Introduction

> 請說明此 Pull Request 的目的
-  將 perseus core 的 peerDependencies react 設為 17 or 18 版，讓我們升級 react 到 18 版時不會被卡住

#### How to verify

> 請說明如何驗證此 Pull Request 的改動可以達成目的（或是做過哪些驗證）
- 升級 react 到 v18 不會有 @junyiacademy/perseus-core 的 install error

