### PR TITLE
Feat: export KhanAnswerTypes from khan perseus

### DIFF
--- a/packages/index.ts
+++ b/packages/index.ts
@@ -1,6 +1,7 @@
 import {parse, compare} from "./kas/src";
 import {init, Widgets, Renderer, Dependencies} from "./perseus/src";
 import KhanUtils from "./perseus/src/util";
+import KhanAnswerTypesUtils from "./perseus/src/util/answer-types";
 import GraphUtils from "./perseus/src/util/graphie";
 
 export interface TexOptions {
@@ -16,6 +17,7 @@ export interface PerseusCore {
     Renderer: typeof Renderer;
     GraphUtils: typeof GraphUtils;
     KhanUtils: typeof KhanUtils;
+    KhanAnswerTypesUtils: typeof KhanAnswerTypesUtils;
     parseTex: (
         tex: string,
         options?: TexOptions,
@@ -41,6 +43,7 @@ export {
     GraphUtils,
     Dependencies,
     KhanUtils,
+    KhanAnswerTypesUtils,
 };
 
 export type {WidgetExports} from "./perseus/src";

--- a/packages/package.json
+++ b/packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junyiacademy/perseus-core",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
> Pull Request Title 請加上 prefix，e.g. New:/Fix:/Change:/Refactor:/Chore:/Test:/Doc: ...

**Notion Link:** https://www.notion.so/junyiacademy/Input-number-Widget-6cafdae735534265a65dfd90f217c8a5?pvs=4

#### Introduction

> 請說明此 Pull Request 的目的
- InputNumber widget 會用到 KhanAnswerTypes

#### How to verify

> 請說明如何驗證此 Pull Request 的改動可以達成目的（或是做過哪些驗證）
- 可以在主站 repo 使用到 perseus 的 KhanAnswerTypes （export 時有改名為 KhanAnswerTypesUtils，因為 types 結尾容易誤會是 type）