### PR TITLE
Fix: iOS < 17 not support look behind

### DIFF
--- a/packages/package.json
+++ b/packages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@junyiacademy/perseus-core",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",

--- a/packages/simple-markdown/src/legacyMarkdownAdapter.ts
+++ b/packages/simple-markdown/src/legacyMarkdownAdapter.ts
@@ -1,18 +1,18 @@
 export const adaptLegacyMarkdown = (str: string) => {
     // heading 前只有一個 \n 時，將 \n 改為 \n\n
     const addedNewLineAboveHeadingStr = str.replace(
-        /(?<=[^\n]\n *)(#{1,6}.*)/g,
-        "\n$1",
+        /([^\n]\n *)(#{1,6}.*)/g,
+        "$1\n$2",
     );
     // heading 後只有一個 \n 時，將 \n 改為 \n\n
     const addedNewLineUnderHeadingStr = addedNewLineAboveHeadingStr.replace(
-        /(?<=\n *|^)(#{1,6}[^\n]*)(?=\n[^\n])/g,
-        "$1\n",
+        /(\n *|^)(#{1,6}[^\n]*)(?=\n[^\n])/g,
+        "$1$2\n",
     );
     // hr 後只有一個 \n 時，將 \n 改為 \n\n
     const addedNewLineUnderHrStr = addedNewLineUnderHeadingStr.replace(
-        /(?<=\n *)([-*_]{3,})(?=\n[^\n])/g,
-        "$1\n",
+        /(\n *)([-*_]{3,})(?=\n[^\n])/g,
+        "$1$2\n",
     );
 
     return addedNewLineUnderHrStr;


### PR DESCRIPTION
Issue:

https://www.notion.so/junyiacademy/legacy-markdown-1278e22e5164808d92d6c5b7696d3bf1

如標題，需要用一些 workaround 的方式寫 regex